### PR TITLE
Add missing qt_gui_cpp dependency to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>qtbase5-dev</depend>
+  <depend>qt_gui_cpp</depend>
   <depend>rqt_gui_cpp</depend>
   <depend>rqt_gui</depend>
   <depend>udp_bridge_interfaces</depend>


### PR DESCRIPTION
## Summary

- Add missing `qt_gui_cpp` dependency to `package.xml`
- `CMakeLists.txt` already has `find_package(qt_gui_cpp REQUIRED)` and links against `${qt_gui_cpp_TARGETS}`, but `package.xml` didn't declare it
- Causes `rosdep install` to miss it in clean environments

Closes #1

## Test plan

- [ ] `rosdep install --from-paths` resolves `qt_gui_cpp` 
- [ ] Package builds in a clean environment

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
