### PR TITLE
UX redesign (PR 1A): tab layout, filters, structured detail tables

### DIFF
--- a/.agent/work-plans/issue-5/plan.md
+++ b/.agent/work-plans/issue-5/plan.md
@@ -1,0 +1,133 @@
+# Plan: UX redesign — PR 1A (layout refactor + filters)
+
+## Issue
+
+https://github.com/rolker/rqt_udp_bridge/issues/5
+
+Scope of **this plan is PR 1A only**. PR 1B (context menus + dialog split) and
+Phase 2 (destructive actions, gated on
+[rolker/udp_bridge#14](https://github.com/rolker/udp_bridge/issues/14)) are
+separate PRs on the same branch family, planned later.
+
+## Context
+
+`udp_bridge_plugin.cpp` (351 lines) + `udp_bridge_plugin.ui` (212) currently
+stack four browse trees (`localTopicsTreeView`, `remotesTreeView`,
+`remoteTopicsTreeView`, `remoteRemotesTreeView`) in one vertical `splitter`
+with a hard-coded `#3030FF` handle stylesheet. No filters; per-connection
+detail is a single concatenated string pushed to `selectedRemotedetailsLabel`
+via `BridgeNode::remoteDetailsUpdated(remote, connection, details)` (built at
+`bridge_node.cpp:362-364`). Models are `QStandardItemModel`s owned by
+`BridgeNode`, swapped onto the views with `setModel()` on node/remote change;
+per-remote models are created on demand (`remoteTopicsModel(remote)`).
+Staleness greying lives in the model via `TimestampRole` (`bridge_node.h:58`).
+
+PR 1A replaces the splitter with a `QTabWidget` + persistent active-remote
+header, adds a key/value detail table, and wraps each tree in a filtering proxy
+— all UI-side, wrapping services that already exist.
+
+## Approach
+
+1. **`.ui` rebuild** — Replace the `splitter` with the layout from the issue's
+   sketch: toolbar (unchanged for 1A) → header `QFrame`
+   (`activeRemoteComboBox` + `headlineStatsLabel`) → `QTabWidget` with tabs
+   `Local Topics` · `Remotes` · `Topics @ <remote>` · `Peers @ <remote>`.
+   Per-remote tabs are `QStackedWidget`: empty-state placeholder vs content.
+   Remotes tab is a horizontal `QSplitter`: tree + `selectedRemoteDetailsTable`
+   (`QTableView`). Each tab gets a filter row (line-edit · Hide idle · Show
+   failing · columns ▾). The `#3030FF` stylesheet disappears with the splitter.
+2. **Structured detail accessor in `BridgeNode`** *(settled with Roland)* —
+   in the same loop at `bridge_node.cpp:362-364`, keep the tooltip string
+   (still used for row hover) but additionally emit structured pairs. Change
+   the signal to `remoteDetailsUpdated(QString remote, QString connection,
+   QList<QPair<QString,QString>> fields)`. A small `QStandardItemModel`
+   (key|value) in the plugin rebuilds on that signal and backs
+   `selectedRemoteDetailsTable`. `selectedRemotedetailsLabel` and the string
+   form of the signal are removed. No re-parsing in the view.
+3. **Stable per-tree `QSortFilterProxyModel`** — one proxy per tree, created
+   once in `initPlugin` and never rebuilt. On node/remote change call
+   `proxy->setSourceModel(newModel)` (not `view->setModel(newProxy)`), so
+   filter text + hidden-column state survive remote switches. Set
+   `setRecursiveFilteringEnabled(true)` so a surviving leaf keeps its parent
+   row visible (parent rows — remote/topic names — carry no stats).
+4. **`mapToSource()` in the tree-walk helpers** — `getRemoteConnection()` and
+   `getTopicRemoteConnection()` (lines 255-290) walk `parent()` chains on the
+   source model. With proxies in place, `currentChanged` delivers proxy
+   indices, so each helper must `mapToSource()` first. This is the highest-risk
+   change in 1A — covered by tests in step 7.
+5. **Filter row behavior** — line-edit → `setFilterFixedString` on column 0;
+   `Hide idle` → custom `filterAcceptsRow` using `TimestampRole` staleness;
+   `Show only failing` → rows with nonzero `failed`+`dropped`; columns ▾ →
+   `QMenu` toggling `view->setColumnHidden`. Combine idle/failing predicates in
+   a `QSortFilterProxyModel` subclass.
+6. **Active-remote combo as single source of truth** — combo selection drives
+   the per-remote `QStackedWidget` content and the `Topics @`/`Peers @` tab
+   labels; the Remotes-tree selection updates the combo. Use `blockSignals`
+   discipline so tree→combo→tabs doesn't loop. Folds in the existing
+   `currentRemoteChanged` model-swap logic (lines 293-313).
+7. **Tests** — add a `launch_testing`/`pytest` smoke (plugin loads, no crash)
+   if feasible in CI, **plus** targeted GTest on the proxy index mapping:
+   build a known source tree, wrap in the proxy, assert
+   `getRemoteConnection`/`getTopicRemoteConnection` return the right
+   (remote, connection) / (topic, remote, connection) tuples through the proxy
+   (factor the tree-walk into a free function taking a model+index so it is
+   testable without a live ROS graph).
+8. **Settings persistence** — `saveSettings`/`restoreSettings` gain
+   `active_tab`, `active_remote`, per-tab `filter_text`/`hide_idle`/
+   `show_failing`, and hidden columns. Old settings (just `node`) must load
+   without warnings (verify with the existing `node`-only round-trip).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/udp_bridge_plugin.ui` | Splitter → tabs + header strip + per-tab filter rows + detail `QTableView`; drop `#3030FF` |
+| `src/udp_bridge_plugin.cpp` | Proxy wiring, `mapToSource` in helpers, combo SSOT, filter slots, detail-table model, settings keys |
+| `include/rqt_udp_bridge/udp_bridge_plugin.h` | Proxy members, detail model, filter-state fields; new slots |
+| `src/bridge_node.cpp` | Emit structured detail pairs alongside tooltip string (l.362-365) |
+| `include/rqt_udp_bridge/bridge_node.h` | Change `remoteDetailsUpdated` signature to carry key/value pairs |
+| new: `src/topic_remote_filter_proxy.{h,cpp}` | `QSortFilterProxyModel` subclass (idle/failing predicates) |
+| new: `test/test_index_mapping.cpp` + `CMakeLists.txt` | GTest for proxy index→source tree-walk |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Human control and transparency | Filters + per-row detail surface bridge state at the point of use; no behavior hidden. |
+| A change includes its consequences | `remoteDetailsUpdated` signature change touches every caller (only the plugin); `udp_bridge` README screenshot will need updating post-Phase-1 (noted in PR). |
+| Only what's needed | Three filters + column toggle is the issue's agreed set; no sparklines/unit-toggle (explicitly deferred). |
+| Improve incrementally | 1A is the layout/proxy foundation; context menus (1B) and destructive actions (Phase 2) land separately. |
+| Test what breaks | The proxy index-mapping regression is the real hazard and gets dedicated GTest; rqt Qt+ROS lifecycle limits the rest to smoke. |
+| Workspace vs. project separation | All changes are project-side UI; nothing workspace-portable. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 — Follow ROS 2 Conventions | Marginally | Preserve `plugin.xml`, `pluginlib` export, `rqt_gui_cpp::Plugin` lifecycle; no new packages/interfaces. |
+| 0002 — Worktree isolation | Yes | Landing via `feature/issue-5` worktree + draft PR. |
+| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry written for this plan. |
+
+## Consequences
+
+| If we change... | Also update... | Included? |
+|---|---|---|
+| `remoteDetailsUpdated` signature | `updateCurrentRemoteDetails` + `updateCurrentRemoteRemoteDetails` callers | Yes |
+| `selectedRemotedetailsLabel` removed | `selectedRemoteRemoteDetailsLabel` (remote-remote detail) — mirror to a table or keep label for 1A? | **Open question** |
+| `.ui` object names | any `instance_settings` keys referencing them | Yes (settings step) |
+| plugin layout | `udp_bridge` README screenshot | No — PR note, follow-up |
+
+## Open Questions
+
+- The **remote-remote** detail pane (`selectedRemoteRemoteDetailsLabel`,
+  Peers @ tab) uses the same concatenated-string path. Convert it to a
+  key/value table too in 1A for consistency, or leave it as a label this PR
+  and migrate in 1B? Leaning: convert both now (same accessor, marginal cost).
+- Is `launch_testing` smoke feasible in this repo's CI, or is the GTest
+  index-mapping test the only automated coverage for 1A? (CI currently builds
+  on `jazzy`; no existing test dir.)
+
+## Estimated Scope
+
+Single PR (PR 1A). Sizable view-layer rewrite but coherent; the proxy/detail
+plumbing must land together. PR 1B and Phase 2 follow on the same issue.

--- a/.agent/work-plans/issue-5/plan.md
+++ b/.agent/work-plans/issue-5/plan.md
@@ -35,7 +35,9 @@ header, adds a key/value detail table, and wraps each tree in a filtering proxy
    Per-remote tabs are `QStackedWidget`: empty-state placeholder vs content.
    Remotes tab is a horizontal `QSplitter`: tree + `selectedRemoteDetailsTable`
    (`QTableView`). Each tab gets a filter row (line-edit · Hide idle · Show
-   failing · columns ▾). The `#3030FF` stylesheet disappears with the splitter.
+   failing · columns ▾). The `#3030FF` splitter handle stylesheet is removed
+   from the `ui_.splitter->setStyleSheet(...)` call at `udp_bridge_plugin.cpp:28`
+   (it is set in the `.cpp`, not the `.ui`), along with the old splitter.
 2. **Structured detail accessor in `BridgeNode`** *(settled with Roland)* —
    in the same loop at `bridge_node.cpp:362-364`, keep the tooltip string
    (still used for row hover) but additionally emit structured pairs. Change
@@ -43,7 +45,13 @@ header, adds a key/value detail table, and wraps each tree in a filtering proxy
    QList<QPair<QString,QString>> fields)`. A small `QStandardItemModel`
    (key|value) in the plugin rebuilds on that signal and backs
    `selectedRemoteDetailsTable`. `selectedRemotedetailsLabel` and the string
-   form of the signal are removed. No re-parsing in the view.
+   form of the signal are removed. No re-parsing in the view. The **remote-remote
+   (Peers @) detail pane converts too** (`selectedRemoteRemoteDetailsLabel` →
+   key/value table): `remoteDetailsUpdated` is consumed by both
+   `updateCurrentRemoteDetails` and `updateCurrentRemoteRemoteDetails`
+   (`udp_bridge_plugin.cpp:309`), so the signature change forces reworking the
+   remote-remote handler regardless — keeping it a label would leave a
+   half-migrated signal. Convert both for one clean signal.
 3. **Stable per-tree `QSortFilterProxyModel`** — one proxy per tree, created
    once in `initPlugin` and never rebuilt. On node/remote change call
    `proxy->setSourceModel(newModel)` (not `view->setModel(newProxy)`), so
@@ -81,8 +89,8 @@ header, adds a key/value detail table, and wraps each tree in a filtering proxy
 
 | File | Change |
 |------|--------|
-| `src/udp_bridge_plugin.ui` | Splitter → tabs + header strip + per-tab filter rows + detail `QTableView`; drop `#3030FF` |
-| `src/udp_bridge_plugin.cpp` | Proxy wiring, `mapToSource` in helpers, combo SSOT, filter slots, detail-table model, settings keys |
+| `src/udp_bridge_plugin.ui` | Splitter → tabs + header strip + per-tab filter rows + detail `QTableView` (both remote and remote-remote) |
+| `src/udp_bridge_plugin.cpp` | Proxy wiring, `mapToSource` in helpers, combo SSOT, filter slots, detail-table models, settings keys, remove `#3030FF` `setStyleSheet` (l.28) |
 | `include/rqt_udp_bridge/udp_bridge_plugin.h` | Proxy members, detail model, filter-state fields; new slots |
 | `src/bridge_node.cpp` | Emit structured detail pairs alongside tooltip string (l.362-365) |
 | `include/rqt_udp_bridge/bridge_node.h` | Change `remoteDetailsUpdated` signature to carry key/value pairs |
@@ -113,19 +121,23 @@ header, adds a key/value detail table, and wraps each tree in a filtering proxy
 | If we change... | Also update... | Included? |
 |---|---|---|
 | `remoteDetailsUpdated` signature | `updateCurrentRemoteDetails` + `updateCurrentRemoteRemoteDetails` callers | Yes |
-| `selectedRemotedetailsLabel` removed | `selectedRemoteRemoteDetailsLabel` (remote-remote detail) — mirror to a table or keep label for 1A? | **Open question** |
+| `selectedRemotedetailsLabel` removed | `selectedRemoteRemoteDetailsLabel` → also converted to key/value table (signal change forces it) | Yes |
 | `.ui` object names | any `instance_settings` keys referencing them | Yes (settings step) |
 | plugin layout | `udp_bridge` README screenshot | No — PR note, follow-up |
 
 ## Open Questions
 
-- The **remote-remote** detail pane (`selectedRemoteRemoteDetailsLabel`,
-  Peers @ tab) uses the same concatenated-string path. Convert it to a
-  key/value table too in 1A for consistency, or leave it as a label this PR
-  and migrate in 1B? Leaning: convert both now (same accessor, marginal cost).
-- Is `launch_testing` smoke feasible in this repo's CI, or is the GTest
-  index-mapping test the only automated coverage for 1A? (CI currently builds
-  on `jazzy`; no existing test dir.)
+*(Both resolved during review-plan — [PR #6](https://github.com/rolker/rqt_udp_bridge/pull/6) `## Plan Review`, `76cb766`.)*
+
+- ~~Convert the remote-remote (Peers @) detail pane in 1A, or defer?~~
+  **Resolved: convert both now.** `remoteDetailsUpdated` feeds both the remote
+  and remote-remote handlers, so the signature change forces touching
+  `updateCurrentRemoteRemoteDetails` regardless — "keep it a label" would only
+  leave a half-migrated signal. Folded into Approach step 2.
+- ~~`launch_testing` smoke vs. GTest-only coverage?~~ **Resolved: timeboxed to
+  implementation.** The committed GTest proxy index-mapping test is the
+  guaranteed 1A coverage; add a `launch_testing` load-smoke only if it drops in
+  cheaply on `jazzy` CI (no existing test dir), else skip without blocking.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-5/plan.md
+++ b/.agent/work-plans/issue-5/plan.md
@@ -94,8 +94,10 @@ header, adds a key/value detail table, and wraps each tree in a filtering proxy
 | `include/rqt_udp_bridge/udp_bridge_plugin.h` | Proxy members, detail model, filter-state fields; new slots |
 | `src/bridge_node.cpp` | Emit structured detail pairs alongside tooltip string (l.362-365) |
 | `include/rqt_udp_bridge/bridge_node.h` | Change `remoteDetailsUpdated` signature to carry key/value pairs |
-| new: `src/topic_remote_filter_proxy.{h,cpp}` | `QSortFilterProxyModel` subclass (idle/failing predicates) |
-| new: `test/test_index_mapping.cpp` + `CMakeLists.txt` | GTest for proxy index→source tree-walk |
+| `include/rqt_udp_bridge/topic_remote_filter_proxy.h` + `src/topic_remote_filter_proxy.cpp` | `QSortFilterProxyModel` subclass (text/idle/failing predicates, recursive) |
+| `include/rqt_udp_bridge/model_navigation.h` + `src/model_navigation.cpp` | Tree-walk extracted to free functions (`mapToSource`, `remoteConnectionAt`, `topicRemoteConnectionAt`) so it is unit-testable; the plugin's helpers delegate here |
+| `test/test_model_navigation.cpp` | GTest: proxy index→source mapping (incl. row-shift regression) + filter predicates |
+| `CMakeLists.txt` / `package.xml` | New sources + MOC header; `ament_cmake_gtest` test target and `test_depend` |
 
 ## Principles Self-Check
 
@@ -143,3 +145,21 @@ header, adds a key/value detail table, and wraps each tree in a filtering proxy
 
 Single PR (PR 1A). Sizable view-layer rewrite but coherent; the proxy/detail
 plumbing must land together. PR 1B and Phase 2 follow on the same issue.
+
+## Implementation Notes
+
+- **`launch_testing` smoke skipped.** No existing test dir and a plugin load
+  needs a display; the GTest (`test_model_navigation.cpp`, 8 cases) is the
+  automated 1A coverage. Plugin-load + live-bridge behavior is the manual smoke
+  checklist on the issue.
+- **"Hide idle" reuses the staleness machinery, not a wall clock.** A leaf is
+  "active" iff a data cell has a valid `TimestampRole` and *no* grey
+  `ForegroundRole` — i.e. exactly the cells `BridgeNode::checkStaleness` keeps
+  fresh. This ties the filter to the same greying users already see and avoids a
+  second clock in the proxy. The "0 Bps" sentinel for "show failing" is coupled
+  to `humanReadableDataRate(0)`; both couplings are documented in
+  `topic_remote_filter_proxy.h`.
+- **Detail responsiveness via a cache.** `remoteDetailsUpdated` fires for every
+  connection each `BridgeInfo`; the plugin caches all of them by
+  (remote, connection) so selecting a row fills the detail table immediately
+  rather than waiting for the next update.

--- a/.agent/work-plans/issue-5/progress.md
+++ b/.agent/work-plans/issue-5/progress.md
@@ -31,3 +31,21 @@ issue: 5
 - [ ] (suggestion) The Peers @ "table vs label" open question is partly forced: `remoteDetailsUpdated` is emitted to BOTH `updateCurrentRemoteDetails` and `updateCurrentRemoteRemoteDetails` (the latter wired at `udp_bridge_plugin.cpp:309`). Changing the signal signature requires reworking the remote-remote handler regardless, so "keep it a label this PR" is not a no-touch option. Recommend resolving to the plan's own lean (convert both) to avoid a half-migrated signal. — `plan.md:116`
 - [ ] (suggestion) Timebox the `launch_testing`-feasibility open question during implementation rather than leaving it open; the committed GTest index-mapping test is the guaranteed 1A coverage either way. — `plan.md:127`
 - [ ] (suggestion) Issue alignment and any `review-issue` comments could not be independently verified — no `gh` auth in this review environment. File targeting and line refs were verified directly against source instead. — `plan.md:3`
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-15 01:41 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-5 at `1ec0b67`
+**Mode**: pre-push
+**Depth**: Deep (reason: ~1150 LOC C++ Qt model/proxy/signal/lifecycle rewrite)
+**Must-fix**: 0 | **Suggestions**: 1 (acted on)
+
+### Findings
+- [x] (acted) Register `DetailFields` metatype for the `remoteDetailsUpdated` signal — defensive future-proofing for any queued connection (current emit is same-thread/direct). Fixed in `1ec0b67`. — `bridge_node.h` / `bridge_node.cpp`
+- [ ] (false positive) Dangling per-remote source models on node change — handled: `onNodeChanged` nulls proxy sources via `setActiveRemote("")` before `setTopicsPrefix` deletes children; all GUI-thread serial. — `udp_bridge_plugin.cpp`
+- [ ] (false positive) `filterAcceptsRow` nullptr source deref — guarded by `if(!model) return true` before any source access. — `topic_remote_filter_proxy.cpp`
+- [ ] (false positive) Column-menu-built flag / failure-column bounds — topics model has 7 columns (cols 4/5 valid); columns structurally identical across remotes; out-of-range index reads return empty (safe). — `udp_bridge_plugin.cpp`, `topic_remote_filter_proxy.cpp`
+- [ ] (dropped) 186 cpplint whitespace/line-length nits — repo has no `ament_lint` gate; compact style matches the existing file. — repo-wide

--- a/.agent/work-plans/issue-5/progress.md
+++ b/.agent/work-plans/issue-5/progress.md
@@ -14,8 +14,8 @@ issue: 5
 **Phases**: PR 1A planned here; 1B + Phase 2 are separate PRs on this issue
 
 ### Open questions
-- [ ] Convert the remote-remote (Peers @) detail pane to a key/value table in 1A too, or keep it a label until 1B?
-- [ ] Is `launch_testing` smoke feasible in this repo's CI, or is the GTest proxy index-mapping test the only automated 1A coverage?
+- [x] Convert the remote-remote (Peers @) detail pane to a key/value table in 1A too? → **Yes, convert both** (signal-signature change forces touching the remote-remote handler; resolved in `## Plan Review`).
+- [x] Is `launch_testing` smoke feasible in this repo's CI? → **Timeboxed to implementation**; GTest proxy index-mapping is the guaranteed coverage either way.
 
 ## Plan Review
 **Status**: complete

--- a/.agent/work-plans/issue-5/progress.md
+++ b/.agent/work-plans/issue-5/progress.md
@@ -1,0 +1,18 @@
+---
+issue: 5
+---
+
+# Issue #5 — UX redesign: tab layout, filters, context-menu actions
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-14 23:34 -0400
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-5/plan.md` at `ae2371d`
+**PR**: https://github.com/rolker/rqt_udp_bridge/pull/6 (`[PLAN]` prefix)
+**Phases**: PR 1A planned here; 1B + Phase 2 are separate PRs on this issue
+
+### Open questions
+- [ ] Convert the remote-remote (Peers @) detail pane to a key/value table in 1A too, or keep it a label until 1B?
+- [ ] Is `launch_testing` smoke feasible in this repo's CI, or is the GTest proxy index-mapping test the only automated 1A coverage?

--- a/.agent/work-plans/issue-5/progress.md
+++ b/.agent/work-plans/issue-5/progress.md
@@ -16,3 +16,18 @@ issue: 5
 ### Open questions
 - [ ] Convert the remote-remote (Peers @) detail pane to a key/value table in 1A too, or keep it a label until 1B?
 - [ ] Is `launch_testing` smoke feasible in this repo's CI, or is the GTest proxy index-mapping test the only automated 1A coverage?
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-15 03:52 +0000
+**By**: Claude Code Agent (Claude Opus 4.8) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-5/plan.md` at `ae2371d`
+**PR**: https://github.com/rolker/rqt_udp_bridge/pull/6 (`[PLAN]` prefix)
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (suggestion) `#3030FF` removal mis-attributed to the `.ui` file — the stylesheet is set in `ui_.splitter->setStyleSheet(...)` at `udp_bridge_plugin.cpp:28`, not in the `.ui`. The `.cpp` is already in scope so it gets removed, but fix the file attribution. — `plan.md:84`
+- [ ] (suggestion) The Peers @ "table vs label" open question is partly forced: `remoteDetailsUpdated` is emitted to BOTH `updateCurrentRemoteDetails` and `updateCurrentRemoteRemoteDetails` (the latter wired at `udp_bridge_plugin.cpp:309`). Changing the signal signature requires reworking the remote-remote handler regardless, so "keep it a label this PR" is not a no-touch option. Recommend resolving to the plan's own lean (convert both) to avoid a half-migrated signal. — `plan.md:116`
+- [ ] (suggestion) Timebox the `launch_testing`-feasibility open question during implementation rather than leaving it open; the committed GTest index-mapping test is the guaranteed 1A coverage either way. — `plan.md:127`
+- [ ] (suggestion) Issue alignment and any `review-issue` comments could not be independently verified — no `gh` auth in this review environment. File targeting and line refs were verified directly against source instead. — `plan.md:3`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,15 @@ find_package(Qt5 COMPONENTS Widgets REQUIRED)
 set(rqt_udp_bridge_SRCS
   src/udp_bridge_plugin.cpp
   src/bridge_node.cpp
+  src/topic_remote_filter_proxy.cpp
+  src/model_navigation.cpp
 )
 
+# Headers with Q_OBJECT (MOC'd). model_navigation.h has no Q_OBJECT.
 set(rqt_udp_bridge_HDRS
   include/rqt_udp_bridge/udp_bridge_plugin.h
   include/rqt_udp_bridge/bridge_node.h
+  include/rqt_udp_bridge/topic_remote_filter_proxy.h
 )
 
 set(rqt_udp_bridge_UIS
@@ -81,6 +85,26 @@ install(
 )
 
 pluginlib_export_plugin_description_file(rqt_gui "plugin.xml")
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # MOC the proxy explicitly and disable AUTOMOC on the test target so the
+  # symbol is defined exactly once.
+  qt5_wrap_cpp(rqt_udp_bridge_TEST_MOCS include/rqt_udp_bridge/topic_remote_filter_proxy.h)
+
+  ament_add_gtest(test_model_navigation
+    test/test_model_navigation.cpp
+    src/model_navigation.cpp
+    src/topic_remote_filter_proxy.cpp
+    ${rqt_udp_bridge_TEST_MOCS}
+  )
+  if(TARGET test_model_navigation)
+    set_target_properties(test_model_navigation PROPERTIES AUTOMOC OFF)
+    target_include_directories(test_model_navigation PRIVATE include)
+    target_link_libraries(test_model_navigation Qt5::Widgets)
+  endif()
+endif()
 
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})

--- a/include/rqt_udp_bridge/bridge_node.h
+++ b/include/rqt_udp_bridge/bridge_node.h
@@ -4,6 +4,9 @@
 #include <chrono>
 #include <QObject>
 #include <QStandardItemModel>
+#include <QList>
+#include <QPair>
+#include <QString>
 #include <QTimer>
 #include "rclcpp/rclcpp.hpp"
 #include "udp_bridge_interfaces/msg/bridge_info.hpp"
@@ -13,6 +16,10 @@
 
 namespace rqt_udp_bridge
 {
+
+/// Ordered key/value pairs describing a single remote connection, emitted by
+/// BridgeNode::remoteDetailsUpdated for rendering in a key/value detail table.
+using DetailFields = QList<QPair<QString, QString>>;
 
 class BridgeNode: public QObject
 {
@@ -43,7 +50,10 @@ public:
   QStringList remoteTopics(const std::string &remote);
 
 signals:
-  void remoteDetailsUpdated(QString remote, QString connection, QString details);
+  /// Emitted once per connection on every BridgeInfo update, carrying the
+  /// connection's details as ordered key/value pairs. Consumers (the plugin's
+  /// detail tables) cache by (remote, connection) and render the active one.
+  void remoteDetailsUpdated(QString remote, QString connection, rqt_udp_bridge::DetailFields fields);
 
 private slots:
   void bridgeInfoUpdated();

--- a/include/rqt_udp_bridge/bridge_node.h
+++ b/include/rqt_udp_bridge/bridge_node.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QStandardItemModel>
 #include <QList>
+#include <QMetaType>
 #include <QPair>
 #include <QString>
 #include <QTimer>
@@ -106,5 +107,10 @@ private:
 };
 
 } // namespace rqt_udp_bridge
+
+// Allow DetailFields to cross a queued signal/slot connection if one is ever
+// introduced. The current emit path is same-thread (direct), so this is
+// defensive future-proofing rather than a present requirement.
+Q_DECLARE_METATYPE(rqt_udp_bridge::DetailFields)
 
 #endif

--- a/include/rqt_udp_bridge/model_navigation.h
+++ b/include/rqt_udp_bridge/model_navigation.h
@@ -1,0 +1,31 @@
+#ifndef RQT_UDP_BRIDGE_MODEL_NAVIGATION_H
+#define RQT_UDP_BRIDGE_MODEL_NAVIGATION_H
+
+#include <QModelIndex>
+#include <string>
+#include <utility>
+
+namespace rqt_udp_bridge
+{
+
+using RemoteConnection = std::pair<std::string, std::string>;
+using TopicRemoteConnection = std::pair<std::string, RemoteConnection>;
+
+/// If \p index belongs to a proxy model, return the corresponding source index;
+/// otherwise return \p index unchanged. Centralizes the proxy→source hop so the
+/// tree-walks below always operate in source-model coordinates.
+QModelIndex mapToSource(const QModelIndex& index);
+
+/// Walk a remotes-tree index (remote → connection) to its
+/// (remote_name, connection_id). connection_id is empty when \p index is a
+/// remote (top-level) row. Accepts proxy or source indices.
+RemoteConnection remoteConnectionAt(const QModelIndex& index);
+
+/// Walk a topics-tree index (topic → remote → connection) to its
+/// (topic, (remote_name, connection_id)). Inner fields are empty at the levels
+/// above them. Accepts proxy or source indices.
+TopicRemoteConnection topicRemoteConnectionAt(const QModelIndex& index);
+
+} // namespace rqt_udp_bridge
+
+#endif

--- a/include/rqt_udp_bridge/topic_remote_filter_proxy.h
+++ b/include/rqt_udp_bridge/topic_remote_filter_proxy.h
@@ -1,0 +1,63 @@
+#ifndef RQT_UDP_BRIDGE_TOPIC_REMOTE_FILTER_PROXY_H
+#define RQT_UDP_BRIDGE_TOPIC_REMOTE_FILTER_PROXY_H
+
+#include <QList>
+#include <QSortFilterProxyModel>
+
+namespace rqt_udp_bridge
+{
+
+/// Filtering proxy for the udp_bridge tree models. Supports three independent,
+/// combinable predicates evaluated on leaf rows (the rows that carry stats):
+///
+///  - substring match on the name column (column 0), matching the row itself or
+///    any of its ancestors so typing a remote name reveals its connections;
+///  - "hide idle": hide leaves whose data cells are all stale (greyed) or absent;
+///  - "show failing": keep only leaves with a nonzero failed/dropped data cell.
+///
+/// Non-leaf rows are never accepted on their own merits when any predicate is
+/// active; they appear only via Qt's recursive filtering when a descendant leaf
+/// passes (so an all-idle remote disappears rather than showing empty). The
+/// proxy is created once per tree and kept stable across source-model swaps —
+/// callers use setSourceModel() on remote change, preserving filter state.
+///
+/// Staleness is read from the same TimestampRole / ForegroundRole that
+/// BridgeNode stamps; the "zero" sentinel for failing detection matches
+/// humanReadableDataRate(0) == "0 Bps". Both couplings are intentional and
+/// documented here so a change to BridgeNode's stamping is caught.
+class TopicRemoteFilterProxy : public QSortFilterProxyModel
+{
+  Q_OBJECT
+public:
+  explicit TopicRemoteFilterProxy(QObject* parent = nullptr);
+
+  /// Columns (in source-model coordinates) whose nonzero value marks a row as
+  /// "failing" — the failed/dropped byte-rate columns for the wrapped model.
+  void setFailureColumns(const QList<int>& columns);
+
+public slots:
+  void setFilterText(const QString& text);
+  void setHideIdle(bool hide);
+  void setShowFailing(bool show);
+
+protected:
+  bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+
+private:
+  /// Must match BridgeNode::TimestampRole. A row's data cell is "fresh" when it
+  /// carries a valid TimestampRole and no grey ForegroundRole (set when stale).
+  static constexpr int TimestampRole = Qt::UserRole + 1;
+
+  bool textMatches(const QModelIndex& source_index0) const;
+  bool rowIsActive(int source_row, const QModelIndex& source_parent) const;
+  bool rowIsFailing(int source_row, const QModelIndex& source_parent) const;
+
+  QString text_;
+  bool hide_idle_ = false;
+  bool show_failing_ = false;
+  QList<int> failure_columns_;
+};
+
+} // namespace rqt_udp_bridge
+
+#endif

--- a/include/rqt_udp_bridge/udp_bridge_plugin.h
+++ b/include/rqt_udp_bridge/udp_bridge_plugin.h
@@ -7,18 +7,25 @@
 #include "udp_bridge_interfaces/msg/topic_statistics_array.hpp"
 #include "udp_bridge_interfaces/msg/bridge_info.hpp"
 #include "rqt_udp_bridge/bridge_node.h"
+#include "rqt_udp_bridge/topic_remote_filter_proxy.h"
+
+#include <QMap>
+#include <QStandardItemModel>
 
 class QLabel;
+class QLineEdit;
+class QToolButton;
+class QTreeView;
 
 namespace rqt_udp_bridge
 {
-    
+
 class UDPBridgePlugin: public rqt_gui_cpp::Plugin
 {
   Q_OBJECT
 public:
   UDPBridgePlugin();
-    
+
   void initPlugin(qt_gui_cpp::PluginContext& context) override;
   void shutdownPlugin() override;
   void saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const override;
@@ -32,22 +39,51 @@ private slots:
   void addRemote();
   void subscribe(bool remote_advertise=false);
 
+  /// Single source of truth for which remote drives the per-remote tabs. Called
+  /// by the header combo and (indirectly) by remotes-tree selection.
+  void setActiveRemote(const QString& remote);
+  /// Rebuild the header combo's remote list from the remotes model.
+  void refreshActiveRemoteCombo();
+
   void currentRemoteChanged(const QModelIndex& index, const QModelIndex& previous_index);
   void currentRemoteRemoteChanged(const QModelIndex& index, const QModelIndex& previous_index);
 
   void currentLocalTopicChanged(const QModelIndex& index, const QModelIndex& previous_index);
   void currentRemoteTopicChanged(const QModelIndex& index, const QModelIndex& previous_index);
 
-  void updateCurrentRemoteDetails(QString remote, QString connection, QString details);
-
-  void updateCurrentRemoteRemoteDetails(QString remote, QString connection, QString details);
+  void updateCurrentRemoteDetails(QString remote, QString connection, rqt_udp_bridge::DetailFields fields);
+  void updateCurrentRemoteRemoteDetails(QString remote, QString connection, rqt_udp_bridge::DetailFields fields);
 
 private:
   using RemoteConnectionID = std::pair<std::string, std::string>;
   using TopicRemoteConnection = std::pair<std::string, RemoteConnectionID>;
 
+  // Per-tab filter controls, built programmatically above each tree.
+  struct FilterControls
+  {
+    QLineEdit* text = nullptr;
+    QToolButton* hide_idle = nullptr;
+    QToolButton* show_failing = nullptr;
+    QToolButton* columns = nullptr;
+  };
+
   RemoteConnectionID getRemoteConnection(const QModelIndex& index);
   TopicRemoteConnection getTopicRemoteConnection(const QModelIndex& index);
+
+  /// Wraps a source-model index out of a (possibly proxied) view index.
+  static QModelIndex mapToSourceIfProxy(const QModelIndex& index);
+
+  /// Build a filter row (text + hide-idle + show-failing + columns) and insert
+  /// it at the top of \p layout, wiring it to \p proxy / \p view.
+  FilterControls buildFilterRow(QBoxLayout* layout, TopicRemoteFilterProxy* proxy, QTreeView* view);
+  /// (Re)populate \p button's column-visibility menu from \p view's model.
+  void buildColumnMenu(QToolButton* button, QTreeView* view);
+
+  static void populateDetailTable(QStandardItemModel& model, const DetailFields& fields);
+
+  // Settings helpers (column hide state is serialized as a comma-separated list).
+  static QString hiddenColumnsString(const QTreeView* view);
+  static void applyHiddenColumns(QTreeView* view, const QString& csv);
 
   Ui::UDPBridgeWidget ui_;
   QWidget* widget_ = nullptr;
@@ -65,10 +101,35 @@ private:
 
   BridgeNode* bridge_node_ = nullptr;
 
-  QMetaObject::Connection remote_topic_changed_connection_;
-  QMetaObject::Connection remote_remote_changed_connection_;
-  QMetaObject::Connection update_remote_remote_details_connection_;
+  // Stable filtering proxies — one per tree, created once, source-model swapped.
+  TopicRemoteFilterProxy* local_topics_proxy_ = nullptr;
+  TopicRemoteFilterProxy* remotes_proxy_ = nullptr;
+  TopicRemoteFilterProxy* remote_topics_proxy_ = nullptr;
+  TopicRemoteFilterProxy* remote_remotes_proxy_ = nullptr;
 
+  FilterControls local_filter_;
+  FilterControls remotes_filter_;
+  FilterControls remote_topics_filter_;
+  FilterControls remote_remotes_filter_;
+
+  // Key/value detail tables, fed from the cached structured details.
+  QStandardItemModel remote_details_model_;
+  QStandardItemModel remote_remote_details_model_;
+  // details_cache_[remote][connection] -> latest fields. The remote-remote cache
+  // is scoped to the active remote and cleared when it changes.
+  QMap<QString, QMap<QString, DetailFields>> details_cache_;
+  QMap<QString, QMap<QString, DetailFields>> remote_remote_details_cache_;
+
+  QMetaObject::Connection update_remote_remote_details_connection_;
+  bool remote_columns_menu_built_ = false;
+  bool remote_remotes_columns_menu_built_ = false;
+
+  // Restored-from-settings state, applied once the relevant data is available.
+  QString pending_active_remote_;
+  // Hidden-column CSVs for the per-remote views, applied when their source model
+  // is first attached (the local/remotes views are applied directly on restore).
+  QString pending_remote_topics_hidden_;
+  QString pending_remote_remotes_hidden_;
 };
 
 } // namespace rqt_udp_bridge

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
   <depend>rqt_gui</depend>
   <depend>udp_bridge_interfaces</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/src/bridge_node.cpp
+++ b/src/bridge_node.cpp
@@ -359,10 +359,25 @@ void BridgeNode::bridgeInfoUpdated()
         connection_item = new QStandardItem(connection.connection_id.c_str());
         item->appendRow(connection_item);
       }
-      std::stringstream tooltip;
-      tooltip << "remote: " << remote.name << " connection: " << connection.connection_id << " host: " << connection.host << " port: " << connection.port << " ip address: " << connection.ip_address << " return host: " << connection.return_host << " return port: " << connection.return_port << " source ip: " << connection.source_ip_address << " source port: " << connection.source_port << " max rate: " << connection.maximum_bytes_per_second << " bytes/sec";
-      connection_item->setData(tooltip.str().c_str(), Qt::ToolTipRole);
-      emit remoteDetailsUpdated(remote.name.c_str(), connection.connection_id.c_str(), tooltip.str().c_str());
+      // Structured key/value pairs back the detail table; the same data is
+      // joined into a tooltip string for row hover.
+      DetailFields fields;
+      fields.append(qMakePair<QString, QString>("remote", remote.name.c_str()));
+      fields.append(qMakePair<QString, QString>("connection", connection.connection_id.c_str()));
+      fields.append(qMakePair<QString, QString>("host", connection.host.c_str()));
+      fields.append(qMakePair<QString, QString>("port", QString::number(connection.port)));
+      fields.append(qMakePair<QString, QString>("ip address", connection.ip_address.c_str()));
+      fields.append(qMakePair<QString, QString>("return host", connection.return_host.c_str()));
+      fields.append(qMakePair<QString, QString>("return port", QString::number(connection.return_port)));
+      fields.append(qMakePair<QString, QString>("source ip", connection.source_ip_address.c_str()));
+      fields.append(qMakePair<QString, QString>("source port", QString::number(connection.source_port)));
+      fields.append(qMakePair<QString, QString>("max rate", QString::number(connection.maximum_bytes_per_second) + " bytes/sec"));
+
+      QStringList tooltip_parts;
+      for(const auto& field: fields)
+        tooltip_parts << field.first + ": " + field.second;
+      connection_item->setData(tooltip_parts.join(" "), Qt::ToolTipRole);
+      emit remoteDetailsUpdated(remote.name.c_str(), connection.connection_id.c_str(), fields);
       std::vector<QString> values;
       values.push_back(humanReadableDataRate(connection.received_bytes_per_second));
       values.push_back(humanReadableDataRate(connection.duplicate_bytes_per_second));

--- a/src/bridge_node.cpp
+++ b/src/bridge_node.cpp
@@ -13,6 +13,7 @@ using namespace udp_bridge_interfaces::srv;
 BridgeNode::BridgeNode(QObject* parent):
   QObject(parent)
 {
+  qRegisterMetaType<DetailFields>();
   connect(&stale_timer_, &QTimer::timeout, this, &BridgeNode::checkStaleness);
   stale_timer_.start(2000);
 }

--- a/src/model_navigation.cpp
+++ b/src/model_navigation.cpp
@@ -1,0 +1,53 @@
+#include "rqt_udp_bridge/model_navigation.h"
+
+#include <QAbstractItemModel>
+#include <QAbstractProxyModel>
+
+namespace rqt_udp_bridge
+{
+
+QModelIndex mapToSource(const QModelIndex& index)
+{
+  if(const auto* proxy = qobject_cast<const QAbstractProxyModel*>(index.model()))
+    return proxy->mapToSource(index);
+  return index;
+}
+
+RemoteConnection remoteConnectionAt(const QModelIndex& index)
+{
+  auto i = mapToSource(index);
+  if(i.isValid() && i.column() != 0)
+    i = i.model()->sibling(i.row(), 0, i);
+
+  while(i.isValid())
+    if(i.parent().isValid()) // i is not remote
+      if(i.parent().parent().isValid()) // i is not connection
+        i = i.parent();
+      else
+        return std::make_pair(i.model()->data(i.parent()).toString().toStdString(), i.model()->data(i).toString().toStdString());
+    else // i is remote
+      return std::make_pair(i.model()->data(i).toString().toStdString(), std::string());
+  return {};
+}
+
+TopicRemoteConnection topicRemoteConnectionAt(const QModelIndex& index)
+{
+  auto i = mapToSource(index);
+  if(i.isValid() && i.column() != 0)
+    i = i.model()->sibling(i.row(), 0, i);
+
+  while(i.isValid())
+    if(i.parent().isValid()) // i is not topic
+      if(i.parent().parent().isValid()) // i is not remote
+        if(i.parent().parent().parent().isValid()) // i is not connection
+          i = i.parent();
+        else
+          return std::make_pair(i.model()->data(i.parent().parent()).toString().toStdString(), std::make_pair(i.model()->data(i.parent()).toString().toStdString(), i.model()->data(i).toString().toStdString()));
+      else // i is remote
+        return std::make_pair(i.model()->data(i.parent()).toString().toStdString(), std::make_pair(i.model()->data(i).toString().toStdString(), std::string()));
+    else // i is topic
+      return std::make_pair(i.model()->data(i).toString().toStdString(), std::make_pair(std::string(), std::string()));
+  return {};
+}
+
+} // namespace rqt_udp_bridge

--- a/src/topic_remote_filter_proxy.cpp
+++ b/src/topic_remote_filter_proxy.cpp
@@ -1,0 +1,113 @@
+#include "rqt_udp_bridge/topic_remote_filter_proxy.h"
+
+namespace rqt_udp_bridge
+{
+
+TopicRemoteFilterProxy::TopicRemoteFilterProxy(QObject* parent):
+  QSortFilterProxyModel(parent)
+{
+  // Keep a matching leaf's ancestors visible; never sort (preserve source order).
+  setRecursiveFilteringEnabled(true);
+  setDynamicSortFilter(true);
+}
+
+void TopicRemoteFilterProxy::setFailureColumns(const QList<int>& columns)
+{
+  failure_columns_ = columns;
+  invalidateFilter();
+}
+
+void TopicRemoteFilterProxy::setFilterText(const QString& text)
+{
+  if(text_ == text)
+    return;
+  text_ = text;
+  invalidateFilter();
+}
+
+void TopicRemoteFilterProxy::setHideIdle(bool hide)
+{
+  if(hide_idle_ == hide)
+    return;
+  hide_idle_ = hide;
+  invalidateFilter();
+}
+
+void TopicRemoteFilterProxy::setShowFailing(bool show)
+{
+  if(show_failing_ == show)
+    return;
+  show_failing_ = show;
+  invalidateFilter();
+}
+
+bool TopicRemoteFilterProxy::textMatches(const QModelIndex& source_index0) const
+{
+  if(text_.isEmpty())
+    return true;
+  // Match the row itself or any ancestor, so typing a remote name reveals its
+  // connection children (recursive filtering only walks toward ancestors).
+  for(QModelIndex i = source_index0; i.isValid(); i = i.parent())
+    if(i.data(Qt::DisplayRole).toString().contains(text_, Qt::CaseInsensitive))
+      return true;
+  return false;
+}
+
+bool TopicRemoteFilterProxy::rowIsActive(int source_row, const QModelIndex& source_parent) const
+{
+  const QAbstractItemModel* model = sourceModel();
+  for(int col = 1; col < model->columnCount(source_parent); col++)
+  {
+    QModelIndex idx = model->index(source_row, col, source_parent);
+    if(!idx.data(TimestampRole).isValid())
+      continue;
+    // A valid timestamp with no grey ForegroundRole means the cell is fresh;
+    // BridgeNode clears the foreground brush when fresh, sets grey when stale.
+    if(!idx.data(Qt::ForegroundRole).isValid())
+      return true;
+  }
+  return false;
+}
+
+bool TopicRemoteFilterProxy::rowIsFailing(int source_row, const QModelIndex& source_parent) const
+{
+  const QAbstractItemModel* model = sourceModel();
+  for(int col: failure_columns_)
+  {
+    QModelIndex idx = model->index(source_row, col, source_parent);
+    QString value = idx.data(Qt::DisplayRole).toString();
+    if(!value.isEmpty() && value != QStringLiteral("0 Bps"))
+      return true;
+  }
+  return false;
+}
+
+bool TopicRemoteFilterProxy::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
+{
+  const QAbstractItemModel* model = sourceModel();
+  if(!model)
+    return true;
+
+  QModelIndex index0 = model->index(source_row, 0, source_parent);
+  const bool is_leaf = model->rowCount(index0) == 0;
+
+  if(!is_leaf)
+  {
+    // No active predicate: show everything (including any empty parents).
+    if(text_.isEmpty() && !hide_idle_ && !show_failing_)
+      return true;
+    // Otherwise defer to recursive filtering: the parent appears only if one of
+    // its descendant leaves is accepted below.
+    return false;
+  }
+
+  if(!textMatches(index0))
+    return false;
+  if(hide_idle_ && !rowIsActive(source_row, source_parent))
+    return false;
+  if(show_failing_ && !rowIsFailing(source_row, source_parent))
+    return false;
+  return true;
+}
+
+} // namespace rqt_udp_bridge

--- a/src/udp_bridge_plugin.cpp
+++ b/src/udp_bridge_plugin.cpp
@@ -1,4 +1,5 @@
 #include "rqt_udp_bridge/udp_bridge_plugin.h"
+#include "rqt_udp_bridge/model_navigation.h"
 #include "ui_add_remote_dialog.h"
 #include "ui_subscribe_dialog.h"
 
@@ -8,34 +9,93 @@
 
 #include <pluginlib/class_list_macros.hpp>
 
-#include <QLineEdit>
+#include <QAbstractProxyModel>
+#include <QAction>
+#include <QBoxLayout>
+#include <QHeaderView>
 #include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
 #include <QMessageBox>
+#include <QSignalBlocker>
+#include <QToolButton>
+#include <QTreeView>
 
 namespace rqt_udp_bridge
 {
-    
+
+namespace
+{
+// Tab indices, matching the order of tabs declared in udp_bridge_plugin.ui.
+constexpr int kLocalTopicsTab = 0;
+constexpr int kRemoteTopicsTab = 2;
+constexpr int kRemoteRemotesTab = 3;
+
+// QStackedWidget page indices for the per-remote tabs.
+constexpr int kEmptyPage = 0;
+constexpr int kContentPage = 1;
+
+// Failed + dropped byte-rate columns (source-model coordinates) used by the
+// "show failing" filter. The topics model has failed/dropped bytes at 4/5; the
+// remotes model has message/overhead/resend fail+drop at 4,5,7,8,10,11.
+const QList<int> kTopicsFailureColumns = {4, 5};
+const QList<int> kRemotesFailureColumns = {4, 5, 7, 8, 10, 11};
+}  // namespace
+
 UDPBridgePlugin::UDPBridgePlugin():rqt_gui_cpp::Plugin()
 {
   setObjectName("UDPBridge");
 }
- 
+
 void UDPBridgePlugin::initPlugin(qt_gui_cpp::PluginContext& context)
 {
   widget_ = new QWidget();
   ui_.setupUi(widget_);
-  ui_.splitter->setHandleWidth(8);
-  ui_.splitter->setStyleSheet("QSplitter::handle{background: #3030FF;}");
 
   if(!bridge_node_)
     bridge_node_ = new BridgeNode(this);
-  ui_.localTopicsTreeView->setModel(bridge_node_->topicsModel());
-  ui_.remotesTreeView->setModel(bridge_node_->remotesModel());
+
+  // --- Stable filtering proxies (created once, source models swapped later) ---
+  local_topics_proxy_ = new TopicRemoteFilterProxy(this);
+  local_topics_proxy_->setFailureColumns(kTopicsFailureColumns);
+  local_topics_proxy_->setSourceModel(bridge_node_->topicsModel());
+  ui_.localTopicsTreeView->setModel(local_topics_proxy_);
+
+  remotes_proxy_ = new TopicRemoteFilterProxy(this);
+  remotes_proxy_->setFailureColumns(kRemotesFailureColumns);
+  remotes_proxy_->setSourceModel(bridge_node_->remotesModel());
+  ui_.remotesTreeView->setModel(remotes_proxy_);
+
+  remote_topics_proxy_ = new TopicRemoteFilterProxy(this);
+  remote_topics_proxy_->setFailureColumns(kTopicsFailureColumns);
+  ui_.remoteTopicsTreeView->setModel(remote_topics_proxy_);
+
+  remote_remotes_proxy_ = new TopicRemoteFilterProxy(this);
+  remote_remotes_proxy_->setFailureColumns(kRemotesFailureColumns);
+  ui_.remoteRemotesTreeView->setModel(remote_remotes_proxy_);
+
+  // --- Detail key/value tables ---
+  ui_.selectedRemoteDetailsTable->setModel(&remote_details_model_);
+  ui_.selectedRemoteRemoteDetailsTable->setModel(&remote_remote_details_model_);
+
+  // --- Filter rows (built above each tree) ---
+  local_filter_ = buildFilterRow(qobject_cast<QBoxLayout*>(ui_.localTopicsLayout), local_topics_proxy_, ui_.localTopicsTreeView);
+  remotes_filter_ = buildFilterRow(qobject_cast<QBoxLayout*>(ui_.remotesLayout), remotes_proxy_, ui_.remotesTreeView);
+  remote_topics_filter_ = buildFilterRow(qobject_cast<QBoxLayout*>(ui_.remoteTopicsLayout), remote_topics_proxy_, ui_.remoteTopicsTreeView);
+  remote_remotes_filter_ = buildFilterRow(qobject_cast<QBoxLayout*>(ui_.remoteRemotesLayout), remote_remotes_proxy_, ui_.remoteRemotesTreeView);
+
+  // Column menus for the views whose models are already attached.
+  buildColumnMenu(local_filter_.columns, ui_.localTopicsTreeView);
+  buildColumnMenu(remotes_filter_.columns, ui_.remotesTreeView);
+
+  // Per-remote tabs start empty until a remote is selected.
+  ui_.remoteTopicsStack->setCurrentIndex(kEmptyPage);
+  ui_.remoteRemotesStack->setCurrentIndex(kEmptyPage);
 
   widget_->setWindowTitle(widget_->windowTitle() + " (" + QString::number(context.serialNumber()) + ")");
-  
+
   context.addWidget(widget_);
-  
+
   updateNodeList();
   ui_.nodesComboBox->setCurrentIndex(ui_.nodesComboBox->findText(""));
   connect(ui_.nodesComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this, &UDPBridgePlugin::onNodeChanged);
@@ -43,14 +103,24 @@ void UDPBridgePlugin::initPlugin(qt_gui_cpp::PluginContext& context)
   ui_.refreshNodesPushButton->setIcon(QIcon::fromTheme("view-refresh"));
   connect(ui_.refreshNodesPushButton, &QPushButton::pressed, this, &UDPBridgePlugin::updateNodeList);
 
+  // The header combo is the single source of truth for the active remote.
+  connect(ui_.activeRemoteComboBox, &QComboBox::currentTextChanged, this, &UDPBridgePlugin::setActiveRemote);
+
+  // Selection models are stable (the proxy is never replaced), so connect once.
   connect(ui_.remotesTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteChanged);
   connect(ui_.localTopicsTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentLocalTopicChanged);
+  connect(ui_.remoteTopicsTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteTopicChanged);
+  connect(ui_.remoteRemotesTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteRemoteChanged);
 
-  connect(bridge_node_, &BridgeNode::remoteDetailsUpdated, this, & UDPBridgePlugin::updateCurrentRemoteDetails);
-  
-  connect(ui_.addRemotePushButton, &QPushButton::pressed, this, &UDPBridgePlugin::addRemote);
-  connect(ui_.advertisePushButton, &QPushButton::pressed, this, [this](){this->subscribe(true);});
-  connect(ui_.subscribePushButton, &QPushButton::pressed, this, [this](){this->subscribe();});
+  // Keep the header combo's remote list in sync with the remotes model.
+  auto* remotes_model = bridge_node_->remotesModel();
+  connect(remotes_model, &QAbstractItemModel::rowsInserted, this, &UDPBridgePlugin::refreshActiveRemoteCombo);
+  connect(remotes_model, &QAbstractItemModel::rowsRemoved, this, &UDPBridgePlugin::refreshActiveRemoteCombo);
+  connect(remotes_model, &QAbstractItemModel::modelReset, this, &UDPBridgePlugin::refreshActiveRemoteCombo);
+
+  connect(bridge_node_, &BridgeNode::remoteDetailsUpdated, this, &UDPBridgePlugin::updateCurrentRemoteDetails);
+
+  refreshActiveRemoteCombo();
 
   // set node name if passed in as argument
   const QStringList& argv = context.argv();
@@ -66,14 +136,135 @@ void UDPBridgePlugin::shutdownPlugin()
   bridge_node_ = nullptr;
 }
 
+UDPBridgePlugin::FilterControls UDPBridgePlugin::buildFilterRow(QBoxLayout* layout, TopicRemoteFilterProxy* proxy, QTreeView* view)
+{
+  FilterControls controls;
+  auto* row = new QWidget(widget_);
+  auto* row_layout = new QHBoxLayout(row);
+  row_layout->setContentsMargins(0, 0, 0, 0);
+
+  controls.text = new QLineEdit(row);
+  controls.text->setPlaceholderText("Filter…");
+  controls.text->setClearButtonEnabled(true);
+  row_layout->addWidget(controls.text, 1);
+
+  controls.hide_idle = new QToolButton(row);
+  controls.hide_idle->setText("Hide idle");
+  controls.hide_idle->setCheckable(true);
+  controls.hide_idle->setToolTip("Hide rows whose statistics have stopped updating");
+  row_layout->addWidget(controls.hide_idle);
+
+  controls.show_failing = new QToolButton(row);
+  controls.show_failing->setText("Show failing");
+  controls.show_failing->setCheckable(true);
+  controls.show_failing->setToolTip("Show only rows with nonzero failed or dropped bytes");
+  row_layout->addWidget(controls.show_failing);
+
+  controls.columns = new QToolButton(row);
+  controls.columns->setText("Columns");
+  controls.columns->setPopupMode(QToolButton::InstantPopup);
+  controls.columns->setToolTip("Show or hide columns");
+  row_layout->addWidget(controls.columns);
+
+  if(layout)
+    layout->insertWidget(0, row);
+
+  connect(controls.text, &QLineEdit::textChanged, proxy, &TopicRemoteFilterProxy::setFilterText);
+  connect(controls.hide_idle, &QToolButton::toggled, proxy, &TopicRemoteFilterProxy::setHideIdle);
+  connect(controls.show_failing, &QToolButton::toggled, proxy, &TopicRemoteFilterProxy::setShowFailing);
+  // Refresh the column menu's checkmarks each time it is about to open, so a
+  // column hidden via persistence/another path is reflected here too.
+  connect(controls.columns, &QToolButton::pressed, this, [this, button = controls.columns, view]() { buildColumnMenu(button, view); });
+
+  return controls;
+}
+
+void UDPBridgePlugin::buildColumnMenu(QToolButton* button, QTreeView* view)
+{
+  if(!button || !view || !view->model())
+    return;
+  auto* menu = button->menu();
+  if(!menu)
+  {
+    menu = new QMenu(button);
+    button->setMenu(menu);
+  }
+  menu->clear();
+  const int columns = view->model()->columnCount();
+  for(int col = 0; col < columns; col++)
+  {
+    QString label = view->model()->headerData(col, Qt::Horizontal, Qt::DisplayRole).toString();
+    if(label.isEmpty())
+      label = QString("Column %1").arg(col);
+    auto* action = menu->addAction(label);
+    action->setCheckable(true);
+    action->setChecked(!view->isColumnHidden(col));
+    // Column 0 (the name) is always kept to avoid an unusable tree.
+    if(col == 0)
+      action->setEnabled(false);
+    connect(action, &QAction::toggled, view, [view, col](bool checked) { view->setColumnHidden(col, !checked); });
+  }
+}
+
 void UDPBridgePlugin::saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const
 {
-  QString node = ui_.nodesComboBox->currentText();
-  instance_settings.setValue("node", node);
+  (void)plugin_settings;
+  instance_settings.setValue("node", ui_.nodesComboBox->currentText());
+  instance_settings.setValue("active_tab", ui_.tabWidget->currentIndex());
+  instance_settings.setValue("active_remote", ui_.activeRemoteComboBox->currentText());
+
+  auto save_filter = [&](const QString& prefix, const FilterControls& f)
+  {
+    if(f.text)
+      instance_settings.setValue(prefix + "_filter_text", f.text->text());
+    if(f.hide_idle)
+      instance_settings.setValue(prefix + "_hide_idle", f.hide_idle->isChecked());
+    if(f.show_failing)
+      instance_settings.setValue(prefix + "_show_failing", f.show_failing->isChecked());
+  };
+  save_filter("local", local_filter_);
+  save_filter("remotes", remotes_filter_);
+  save_filter("remote_topics", remote_topics_filter_);
+  save_filter("remote_remotes", remote_remotes_filter_);
+
+  instance_settings.setValue("local_hidden_cols", hiddenColumnsString(ui_.localTopicsTreeView));
+  instance_settings.setValue("remotes_hidden_cols", hiddenColumnsString(ui_.remotesTreeView));
+  instance_settings.setValue("remote_topics_hidden_cols", hiddenColumnsString(ui_.remoteTopicsTreeView));
+  instance_settings.setValue("remote_remotes_hidden_cols", hiddenColumnsString(ui_.remoteRemotesTreeView));
 }
 
 void UDPBridgePlugin::restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings)
 {
+  (void)plugin_settings;
+
+  auto restore_filter = [&](const QString& prefix, const FilterControls& f)
+  {
+    if(f.text)
+      f.text->setText(instance_settings.value(prefix + "_filter_text", "").toString());
+    if(f.hide_idle)
+      f.hide_idle->setChecked(instance_settings.value(prefix + "_hide_idle", false).toBool());
+    if(f.show_failing)
+      f.show_failing->setChecked(instance_settings.value(prefix + "_show_failing", false).toBool());
+  };
+  restore_filter("local", local_filter_);
+  restore_filter("remotes", remotes_filter_);
+  restore_filter("remote_topics", remote_topics_filter_);
+  restore_filter("remote_remotes", remote_remotes_filter_);
+
+  // Local/remotes views have their models already; apply column state now.
+  applyHiddenColumns(ui_.localTopicsTreeView, instance_settings.value("local_hidden_cols", "").toString());
+  applyHiddenColumns(ui_.remotesTreeView, instance_settings.value("remotes_hidden_cols", "").toString());
+  // Per-remote views attach their model on first selection; defer.
+  pending_remote_topics_hidden_ = instance_settings.value("remote_topics_hidden_cols", "").toString();
+  pending_remote_remotes_hidden_ = instance_settings.value("remote_remotes_hidden_cols", "").toString();
+
+  int active_tab = instance_settings.value("active_tab", kLocalTopicsTab).toInt();
+  if(active_tab >= 0 && active_tab < ui_.tabWidget->count())
+    ui_.tabWidget->setCurrentIndex(active_tab);
+
+  // The active remote may not exist yet; remember it and select once it appears.
+  pending_active_remote_ = instance_settings.value("active_remote", "").toString();
+
   QString node = instance_settings.value("node", "").toString();
   // don't overwrite topic name passed as command line argument
   if (!arg_node_.isEmpty())
@@ -83,6 +274,35 @@ void UDPBridgePlugin::restoreSettings(const qt_gui_cpp::Settings& plugin_setting
   else
   {
     selectNode(node);
+  }
+}
+
+QString UDPBridgePlugin::hiddenColumnsString(const QTreeView* view)
+{
+  if(!view || !view->model())
+    return {};
+  QStringList hidden;
+  for(int col = 0; col < view->model()->columnCount(); col++)
+    if(view->isColumnHidden(col))
+      hidden << QString::number(col);
+  return hidden.join(",");
+}
+
+void UDPBridgePlugin::applyHiddenColumns(QTreeView* view, const QString& csv)
+{
+  if(!view || !view->model())
+    return;
+  const int columns = view->model()->columnCount();
+  for(int col = 0; col < columns; col++)
+    view->setColumnHidden(col, false);
+  if(csv.isEmpty())
+    return;
+  for(const QString& token: csv.split(",", Qt::SkipEmptyParts))
+  {
+    bool ok = false;
+    int col = token.toInt(&ok);
+    if(ok && col > 0 && col < columns)  // never hide the name column
+      view->setColumnHidden(col, true);
   }
 }
 
@@ -145,16 +365,112 @@ void UDPBridgePlugin::selectNode(const QString& node)
 
 void UDPBridgePlugin::onNodeChanged(int index)
 {
-  active_remote_.clear();
-  active_connection_.clear();
+  // Reset per-remote state before the bridge node clears its child models
+  // (which back remote_topics_proxy_ / remote_remotes_proxy_).
+  setActiveRemote("");
   active_local_topic_.clear();
   active_remote_topic_.clear();
-  ui_.remoteTopicsTreeView->setModel(nullptr);
-  ui_.remoteRemotesTreeView->setModel(nullptr);
+  active_connection_.clear();
+  details_cache_.clear();
 
   QString node = ui_.nodesComboBox->itemData(index).toString();
   node_namespace_ = node.toStdString();
   bridge_node_->setTopicsPrefix(node_, node_namespace_, true);
+}
+
+void UDPBridgePlugin::refreshActiveRemoteCombo()
+{
+  auto* combo = ui_.activeRemoteComboBox;
+  const QString current = QString::fromStdString(active_remote_);
+
+  QStringList remotes;
+  auto* model = bridge_node_->remotesModel();
+  for(int row = 0; row < model->rowCount(); row++)
+    if(auto* item = model->item(row))
+      remotes << item->data(Qt::DisplayRole).toString();
+  remotes.sort();
+
+  QSignalBlocker blocker(combo);
+  combo->clear();
+  combo->addItem("");  // empty selection => no active remote
+  combo->addItems(remotes);
+
+  // Prefer a pending restored selection if it has now appeared.
+  QString desired = current;
+  if(desired.isEmpty() && !pending_active_remote_.isEmpty() && remotes.contains(pending_active_remote_))
+  {
+    desired = pending_active_remote_;
+    pending_active_remote_.clear();
+  }
+  int idx = combo->findText(desired);
+  combo->setCurrentIndex(idx >= 0 ? idx : 0);
+  blocker.unblock();
+
+  // If the selection effectively changed (the active remote vanished, or a
+  // pending one appeared), reconcile the dependent state.
+  if(combo->currentText() != current)
+    setActiveRemote(combo->currentText());
+}
+
+void UDPBridgePlugin::setActiveRemote(const QString& remote)
+{
+  const std::string remote_str = remote.toStdString();
+
+  active_remote_ = remote_str;
+  active_remote_remote_.clear();
+  active_remote_connection_.clear();
+  remote_remote_details_cache_.clear();
+  remote_remote_details_model_.clear();
+
+  // Keep the header combo in sync when driven from elsewhere (tree selection).
+  if(ui_.activeRemoteComboBox->currentText() != remote)
+  {
+    QSignalBlocker blocker(ui_.activeRemoteComboBox);
+    int idx = ui_.activeRemoteComboBox->findText(remote);
+    if(idx >= 0)
+      ui_.activeRemoteComboBox->setCurrentIndex(idx);
+  }
+
+  disconnect(update_remote_remote_details_connection_);
+
+  if(remote_str.empty())
+  {
+    remote_topics_proxy_->setSourceModel(nullptr);
+    remote_remotes_proxy_->setSourceModel(nullptr);
+    ui_.remoteTopicsStack->setCurrentIndex(kEmptyPage);
+    ui_.remoteRemotesStack->setCurrentIndex(kEmptyPage);
+    ui_.tabWidget->setTabText(kRemoteTopicsTab, "Topics @ —");
+    ui_.tabWidget->setTabText(kRemoteRemotesTab, "Peers @ —");
+    ui_.headlineStatsLabel->clear();
+    return;
+  }
+
+  remote_topics_proxy_->setSourceModel(bridge_node_->remoteTopicsModel(remote_str));
+  remote_remotes_proxy_->setSourceModel(bridge_node_->remoteRemotesModel(remote_str));
+  ui_.remoteTopicsStack->setCurrentIndex(kContentPage);
+  ui_.remoteRemotesStack->setCurrentIndex(kContentPage);
+  ui_.tabWidget->setTabText(kRemoteTopicsTab, QString("Topics @ %1").arg(remote));
+  ui_.tabWidget->setTabText(kRemoteRemotesTab, QString("Peers @ %1").arg(remote));
+
+  // Build the per-remote column menus and apply restored column state once.
+  if(!remote_columns_menu_built_)
+  {
+    buildColumnMenu(remote_topics_filter_.columns, ui_.remoteTopicsTreeView);
+    applyHiddenColumns(ui_.remoteTopicsTreeView, pending_remote_topics_hidden_);
+    remote_columns_menu_built_ = true;
+  }
+  if(!remote_remotes_columns_menu_built_)
+  {
+    buildColumnMenu(remote_remotes_filter_.columns, ui_.remoteRemotesTreeView);
+    applyHiddenColumns(ui_.remoteRemotesTreeView, pending_remote_remotes_hidden_);
+    remote_remotes_columns_menu_built_ = true;
+  }
+
+  if(auto* remote_node = bridge_node_->remoteBridgeNode(remote_str))
+    update_remote_remote_details_connection_ = connect(remote_node, &BridgeNode::remoteDetailsUpdated, this, &UDPBridgePlugin::updateCurrentRemoteRemoteDetails);
+
+  const int connection_count = bridge_node_->connections(remote_str).size();
+  ui_.headlineStatsLabel->setText(QString("%1 connection%2").arg(connection_count).arg(connection_count == 1 ? "" : "s"));
 }
 
 void UDPBridgePlugin::addRemote()
@@ -180,7 +496,7 @@ void UDPBridgePlugin::addRemote()
     max_rate = addRemoteDialogUI.returnRateLimitLineEdit->text().toUInt(&ok);
     if(ok)
       add_remote->return_maximum_bytes_per_second = max_rate;
-    
+
     if(!bridge_node_->addRemote(add_remote))
     {
       QMessageBox::warning(widget_, "UDPBridge add remote", "The add_remote service failed.");
@@ -252,98 +568,105 @@ void UDPBridgePlugin::subscribe(bool remote_advertise)
   }
 }
 
+QModelIndex UDPBridgePlugin::mapToSourceIfProxy(const QModelIndex& index)
+{
+  return mapToSource(index);
+}
+
 UDPBridgePlugin::RemoteConnectionID UDPBridgePlugin::getRemoteConnection(const QModelIndex& index)
 {
-  auto i = index;
-  if(i.isValid() && i.column() != 0)
-    i = i.model()->sibling(i.row(), 0, i);
-
-  while(i.isValid())
-    if(i.parent().isValid()) // i is not remote
-      if(i.parent().parent().isValid()) // i is not connection
-        i = i.parent();
-      else
-        return std::make_pair(i.model()->data(i.parent()).toString().toStdString(), i.model()->data(i).toString().toStdString());
-    else // i is remote
-      return std::make_pair(i.model()->data(i).toString().toStdString(), std::string());
-  return {};
+  return remoteConnectionAt(index);
 }
 
 UDPBridgePlugin::TopicRemoteConnection UDPBridgePlugin::getTopicRemoteConnection(const QModelIndex& index)
 {
-  auto i = index;
-  if(i.isValid() && i.column() != 0)
-    i = i.model()->sibling(i.row(), 0, i);
-
-  while(i.isValid())
-    if(i.parent().isValid()) // i is not topic
-      if(i.parent().parent().isValid()) // i is not remote
-        if(i.parent().parent().parent().isValid()) // i is not connection
-          i = i.parent();
-        else
-          return std::make_pair(i.model()->data(i.parent().parent()).toString().toStdString(), std::make_pair(i.model()->data(i.parent()).toString().toStdString(), i.model()->data(i).toString().toStdString()));
-      else // i is remote
-        return std::make_pair(i.model()->data(i.parent()).toString().toStdString(),std::make_pair(i.model()->data(i).toString().toStdString(), std::string()));
-    else // i is topic
-      return std::make_pair(i.model()->data(i).toString().toStdString(),std::make_pair(std::string(), std::string()));
-  return {};
+  return topicRemoteConnectionAt(index);
 }
-
 
 void UDPBridgePlugin::currentRemoteChanged(const QModelIndex& index, const QModelIndex& previous_index)
 {
-  auto previous = getRemoteConnection(previous_index);
+  (void)previous_index;
   auto current = getRemoteConnection(index);
-  active_remote_ = current.first;
   active_connection_ = current.second;
-  ui_.remoteTopicsTreeView->setModel(bridge_node_->remoteTopicsModel(active_remote_));
 
-  disconnect(remote_topic_changed_connection_);
-  ui_.remoteRemotesTreeView->setModel(bridge_node_->remoteRemotesModel(active_remote_));
-  remote_topic_changed_connection_ = connect(ui_.remoteTopicsTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteTopicChanged);
+  // The header combo is the source of truth; selecting a remote in the tree
+  // drives it (which in turn runs setActiveRemote for the per-remote tabs).
+  const QString remote = QString::fromStdString(current.first);
+  if(ui_.activeRemoteComboBox->currentText() != remote)
+  {
+    int idx = ui_.activeRemoteComboBox->findText(remote);
+    if(idx >= 0)
+      ui_.activeRemoteComboBox->setCurrentIndex(idx);  // emits -> setActiveRemote
+    else
+      setActiveRemote(remote);
+  }
 
-  disconnect(remote_remote_changed_connection_);
-  remote_remote_changed_connection_ = connect(ui_.remoteRemotesTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteRemoteChanged);
-
-  disconnect(update_remote_remote_details_connection_);
-  update_remote_remote_details_connection_ = connect(bridge_node_->remoteBridgeNode(active_remote_), &BridgeNode::remoteDetailsUpdated, this, & UDPBridgePlugin::updateCurrentRemoteRemoteDetails);
-
-  ui_.remoteTopicsGroupBox->setTitle(QString("Remote Topics (")+active_remote_.c_str()+")");
-  ui_.remoteRemotesGroupBox->setTitle(QString("Remote Remotes (")+active_remote_.c_str()+")");
+  // Show the selected connection's details immediately from cache, if known.
+  auto remote_it = details_cache_.find(remote);
+  if(remote_it != details_cache_.end())
+  {
+    auto conn_it = remote_it->find(QString::fromStdString(active_connection_));
+    if(conn_it != remote_it->end())
+      populateDetailTable(remote_details_model_, *conn_it);
+  }
 }
 
 void UDPBridgePlugin::currentRemoteRemoteChanged(const QModelIndex& index, const QModelIndex& previous_index)
 {
-  auto previous = getRemoteConnection(previous_index);
+  (void)previous_index;
   auto current = getRemoteConnection(index);
   active_remote_remote_ = current.first;
   active_remote_connection_ = current.second;
-}
 
+  auto remote_it = remote_remote_details_cache_.find(QString::fromStdString(active_remote_remote_));
+  if(remote_it != remote_remote_details_cache_.end())
+  {
+    auto conn_it = remote_it->find(QString::fromStdString(active_remote_connection_));
+    if(conn_it != remote_it->end())
+      populateDetailTable(remote_remote_details_model_, *conn_it);
+  }
+}
 
 void UDPBridgePlugin::currentLocalTopicChanged(const QModelIndex& index, const QModelIndex& previous_index)
 {
+  (void)previous_index;
   auto current = getTopicRemoteConnection(index);
   active_local_topic_ = current.first;
 }
 
 void UDPBridgePlugin::currentRemoteTopicChanged(const QModelIndex& index, const QModelIndex& previous_index)
 {
+  (void)previous_index;
   auto current = getTopicRemoteConnection(index);
   active_remote_topic_ = current.first;
 }
 
-
-void UDPBridgePlugin::updateCurrentRemoteDetails(QString remote, QString connection, QString details)
+void UDPBridgePlugin::populateDetailTable(QStandardItemModel& model, const DetailFields& fields)
 {
-  if(remote.toStdString() == active_remote_ && connection.toStdString() == active_connection_)
-    ui_.selectedRemotedetailsLabel->setText(details);
+  model.clear();
+  model.setHorizontalHeaderLabels({"field", "value"});
+  for(const auto& field: fields)
+  {
+    auto* key = new QStandardItem(field.first);
+    key->setEditable(false);
+    auto* value = new QStandardItem(field.second);
+    value->setEditable(false);
+    model.appendRow(QList<QStandardItem*>{key, value});
+  }
 }
 
-void UDPBridgePlugin::updateCurrentRemoteRemoteDetails(QString remote, QString connection, QString details)
+void UDPBridgePlugin::updateCurrentRemoteDetails(QString remote, QString connection, DetailFields fields)
 {
+  details_cache_[remote][connection] = fields;
+  if(remote.toStdString() == active_remote_ && connection.toStdString() == active_connection_)
+    populateDetailTable(remote_details_model_, fields);
+}
+
+void UDPBridgePlugin::updateCurrentRemoteRemoteDetails(QString remote, QString connection, DetailFields fields)
+{
+  remote_remote_details_cache_[remote][connection] = fields;
   if(remote.toStdString() == active_remote_remote_ && connection.toStdString() == active_remote_connection_)
-    ui_.selectedRemoteRemoteDetailsLabel->setText(QString(active_remote_.c_str())+"'s "+ details);
+    populateDetailTable(remote_remote_details_model_, fields);
 }
 
 } // namespace rqt_udp_bridge

--- a/src/udp_bridge_plugin.ui
+++ b/src/udp_bridge_plugin.ui
@@ -72,94 +72,53 @@
     </widget>
    </item>
    <item>
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QFrame" name="headerFrame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="handleWidth">
-      <number>5</number>
+     <layout class="QHBoxLayout" name="headerLayout">
+      <item>
+       <widget class="QLabel" name="activeRemoteCaptionLabel">
+        <property name="text">
+         <string>Selected remote:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="activeRemoteComboBox">
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+        <property name="minimumContentsLength">
+         <number>12</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="headlineStatsLabel">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <widget class="QGroupBox" name="localTopicsGroupBox">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>2</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="title">
+     <widget class="QWidget" name="localTopicsTab">
+      <attribute name="title">
        <string>Local Topics</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
+      </attribute>
+      <layout class="QVBoxLayout" name="localTopicsLayout">
        <item>
         <widget class="QTreeView" name="localTopicsTreeView">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QGroupBox" name="remotesGroupBox">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>1</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="title">
-       <string>Remotes</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QTreeView" name="remotesTreeView">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::SingleSelection</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="selectedRemotedetailsLabel">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QGroupBox" name="remoteTopicsGroupBox">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>2</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="title">
-       <string>Remote Topics</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <item>
-        <widget class="QTreeView" name="remoteTopicsTreeView">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
          <property name="selectionMode">
           <enum>QAbstractItemView::SingleSelection</enum>
          </property>
@@ -170,35 +129,141 @@
        </item>
       </layout>
      </widget>
-     <widget class="QGroupBox" name="remoteRemotesGroupBox">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>1</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="title">
-       <string>Remote Remotes</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+     <widget class="QWidget" name="remotesTab">
+      <attribute name="title">
+       <string>Remotes</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="remotesLayout">
        <item>
-        <widget class="QTreeView" name="remoteRemotesTreeView">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+        <widget class="QSplitter" name="remotesSplitter">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
+         <widget class="QTreeView" name="remotesTreeView">
+          <property name="selectionMode">
+           <enum>QAbstractItemView::SingleSelection</enum>
+          </property>
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectRows</enum>
+          </property>
+         </widget>
+         <widget class="QTableView" name="selectedRemoteDetailsTable">
+          <property name="editTriggers">
+           <set>QAbstractItemView::NoEditTriggers</set>
+          </property>
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectRows</enum>
+          </property>
+          <attribute name="horizontalHeaderStretchLastSection">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+         </widget>
         </widget>
        </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="remoteTopicsTab">
+      <attribute name="title">
+       <string>Topics @ —</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="remoteTopicsTabLayout">
        <item>
-        <widget class="QLabel" name="selectedRemoteRemoteDetailsLabel">
-         <property name="text">
-          <string/>
+        <widget class="QStackedWidget" name="remoteTopicsStack">
+         <property name="currentIndex">
+          <number>0</number>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         <widget class="QWidget" name="remoteTopicsEmptyPage">
+          <layout class="QVBoxLayout" name="remoteTopicsEmptyLayout">
+           <item>
+            <widget class="QLabel" name="remoteTopicsEmptyLabel">
+             <property name="text">
+              <string>Select a remote to view its topics.</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="remoteTopicsContentPage">
+          <layout class="QVBoxLayout" name="remoteTopicsLayout">
+           <item>
+            <widget class="QTreeView" name="remoteTopicsTreeView">
+             <property name="selectionMode">
+              <enum>QAbstractItemView::SingleSelection</enum>
+             </property>
+             <property name="selectionBehavior">
+              <enum>QAbstractItemView::SelectRows</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="remoteRemotesTab">
+      <attribute name="title">
+       <string>Peers @ —</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="remoteRemotesTabLayout">
+       <item>
+        <widget class="QStackedWidget" name="remoteRemotesStack">
+         <property name="currentIndex">
+          <number>0</number>
          </property>
+         <widget class="QWidget" name="remoteRemotesEmptyPage">
+          <layout class="QVBoxLayout" name="remoteRemotesEmptyLayout">
+           <item>
+            <widget class="QLabel" name="remoteRemotesEmptyLabel">
+             <property name="text">
+              <string>Select a remote to view its peers.</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="remoteRemotesContentPage">
+          <layout class="QVBoxLayout" name="remoteRemotesLayout">
+           <item>
+            <widget class="QSplitter" name="remoteRemotesSplitter">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <widget class="QTreeView" name="remoteRemotesTreeView">
+              <property name="selectionMode">
+               <enum>QAbstractItemView::SingleSelection</enum>
+              </property>
+              <property name="selectionBehavior">
+               <enum>QAbstractItemView::SelectRows</enum>
+              </property>
+             </widget>
+             <widget class="QTableView" name="selectedRemoteRemoteDetailsTable">
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="selectionBehavior">
+               <enum>QAbstractItemView::SelectRows</enum>
+              </property>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
+              </attribute>
+              <attribute name="verticalHeaderVisible">
+               <bool>false</bool>
+              </attribute>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>

--- a/test/test_model_navigation.cpp
+++ b/test/test_model_navigation.cpp
@@ -1,0 +1,194 @@
+// Unit tests for the tree-walk navigation and filter proxy. The highest-risk
+// part of the UX refactor is that selection indices arrive in proxy coordinates
+// and must be mapped to the source model before walking parent chains; these
+// tests pin that down without a live ROS graph.
+
+#include <gtest/gtest.h>
+
+#include <QList>
+#include <QStandardItemModel>
+
+#include "rqt_udp_bridge/model_navigation.h"
+#include "rqt_udp_bridge/topic_remote_filter_proxy.h"
+
+using rqt_udp_bridge::TopicRemoteFilterProxy;
+using rqt_udp_bridge::remoteConnectionAt;
+using rqt_udp_bridge::topicRemoteConnectionAt;
+
+namespace
+{
+// Build a remotes-style tree: remote rows with connection children. Only the
+// name column (0) is populated; that is all the navigation walk reads.
+QStandardItem* makeRemote(const QString& name, const QStringList& connections)
+{
+  auto* remote = new QStandardItem(name);
+  for(const auto& c: connections)
+    remote->appendRow(new QStandardItem(c));
+  return remote;
+}
+
+// A remotes row with 12 columns (name + 11 data), so failure-column filtering
+// can be exercised. value is written into every data column.
+QList<QStandardItem*> makeConnectionRow(const QString& name, const QString& failValue)
+{
+  QList<QStandardItem*> row;
+  row << new QStandardItem(name);
+  for(int col = 1; col < 12; col++)
+    row << new QStandardItem(col == 4 ? failValue : QStringLiteral("0 Bps"));
+  return row;
+}
+}  // namespace
+
+// --- Index mapping: source vs proxy coordinates -----------------------------
+
+TEST(ModelNavigation, RemoteConnectionFromSourceIndex)
+{
+  QStandardItemModel model;
+  model.appendRow(makeRemote("remoteA", {"conn1", "conn2"}));
+
+  QModelIndex remote = model.index(0, 0);
+  QModelIndex conn2 = model.index(1, 0, remote);
+
+  auto rc = remoteConnectionAt(conn2);
+  EXPECT_EQ(rc.first, "remoteA");
+  EXPECT_EQ(rc.second, "conn2");
+}
+
+TEST(ModelNavigation, RemoteTopLevelHasEmptyConnection)
+{
+  QStandardItemModel model;
+  model.appendRow(makeRemote("remoteA", {"conn1"}));
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setSourceModel(&model);
+
+  auto rc = remoteConnectionAt(proxy.index(0, 0));
+  EXPECT_EQ(rc.first, "remoteA");
+  EXPECT_EQ(rc.second, "");
+}
+
+TEST(ModelNavigation, RemoteConnectionFromProxyIndex)
+{
+  QStandardItemModel model;
+  model.appendRow(makeRemote("remoteA", {"conn1", "conn2"}));
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setSourceModel(&model);
+
+  QModelIndex remote = proxy.index(0, 0);
+  QModelIndex conn2 = proxy.index(1, 0, remote);
+
+  auto rc = remoteConnectionAt(conn2);
+  EXPECT_EQ(rc.first, "remoteA");
+  EXPECT_EQ(rc.second, "conn2");
+}
+
+// The regression that motivated extracting this: once a filter drops rows, the
+// proxy row index no longer equals the source row index. Without mapToSource
+// the walk would read the wrong connection.
+TEST(ModelNavigation, ProxyIndexMappingSurvivesRowShift)
+{
+  QStandardItemModel model;
+  model.appendRow(makeRemote("remoteA", {"conn1", "conn2"}));
+  model.appendRow(makeRemote("remoteB", {"conn3"}));
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setSourceModel(&model);
+  proxy.setFilterText("conn2");  // hides conn1 (source row 0) and remoteB
+
+  ASSERT_EQ(proxy.rowCount(), 1);
+  QModelIndex remote = proxy.index(0, 0);
+  EXPECT_EQ(remote.data().toString().toStdString(), "remoteA");
+  ASSERT_EQ(proxy.rowCount(remote), 1);
+
+  QModelIndex visible = proxy.index(0, 0, remote);  // proxy row 0 == source row 1
+  EXPECT_EQ(visible.data().toString().toStdString(), "conn2");
+
+  auto rc = remoteConnectionAt(visible);
+  EXPECT_EQ(rc.first, "remoteA");
+  EXPECT_EQ(rc.second, "conn2");
+}
+
+TEST(ModelNavigation, TopicRemoteConnectionFromProxyIndex)
+{
+  QStandardItemModel model;
+  auto* topic = new QStandardItem("t1");
+  auto* remote = new QStandardItem("rA");
+  remote->appendRow(new QStandardItem("c1"));
+  topic->appendRow(remote);
+  model.appendRow(topic);
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setSourceModel(&model);
+
+  QModelIndex t = proxy.index(0, 0);
+  QModelIndex r = proxy.index(0, 0, t);
+  QModelIndex c = proxy.index(0, 0, r);
+
+  auto leaf = topicRemoteConnectionAt(c);
+  EXPECT_EQ(leaf.first, "t1");
+  EXPECT_EQ(leaf.second.first, "rA");
+  EXPECT_EQ(leaf.second.second, "c1");
+
+  auto mid = topicRemoteConnectionAt(r);
+  EXPECT_EQ(mid.first, "t1");
+  EXPECT_EQ(mid.second.first, "rA");
+  EXPECT_EQ(mid.second.second, "");
+
+  auto top = topicRemoteConnectionAt(t);
+  EXPECT_EQ(top.first, "t1");
+  EXPECT_EQ(top.second.first, "");
+  EXPECT_EQ(top.second.second, "");
+}
+
+// --- Filter predicates ------------------------------------------------------
+
+TEST(FilterProxy, TextFilterKeepsMatchingBranchOnly)
+{
+  QStandardItemModel model;
+  model.appendRow(makeRemote("remoteA", {"conn1", "conn2"}));
+  model.appendRow(makeRemote("remoteB", {"conn3"}));
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setSourceModel(&model);
+  proxy.setFilterText("conn1");
+
+  ASSERT_EQ(proxy.rowCount(), 1);  // remoteB dropped
+  QModelIndex remote = proxy.index(0, 0);
+  EXPECT_EQ(remote.data().toString().toStdString(), "remoteA");
+  ASSERT_EQ(proxy.rowCount(remote), 1);  // only conn1
+  EXPECT_EQ(proxy.index(0, 0, remote).data().toString().toStdString(), "conn1");
+}
+
+TEST(FilterProxy, ShowFailingKeepsOnlyNonzeroRows)
+{
+  QStandardItemModel model;
+  auto* remote = new QStandardItem("remoteA");
+  remote->appendRow(makeConnectionRow("connOk", "0 Bps"));
+  remote->appendRow(makeConnectionRow("connFail", "5 Bps"));
+  model.appendRow(remote);
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setFailureColumns({4, 5, 7, 8, 10, 11});
+  proxy.setSourceModel(&model);
+  proxy.setShowFailing(true);
+
+  ASSERT_EQ(proxy.rowCount(), 1);  // remoteA kept via failing child
+  QModelIndex pa = proxy.index(0, 0);
+  ASSERT_EQ(proxy.rowCount(pa), 1);
+  EXPECT_EQ(proxy.index(0, 0, pa).data().toString().toStdString(), "connFail");
+}
+
+TEST(FilterProxy, NoPredicatesShowsEverything)
+{
+  QStandardItemModel model;
+  model.appendRow(makeRemote("remoteA", {"conn1", "conn2"}));
+  model.appendRow(makeRemote("remoteB", {"conn3"}));
+
+  TopicRemoteFilterProxy proxy;
+  proxy.setSourceModel(&model);
+
+  EXPECT_EQ(proxy.rowCount(), 2);
+  EXPECT_EQ(proxy.rowCount(proxy.index(0, 0)), 2);
+  EXPECT_EQ(proxy.rowCount(proxy.index(1, 0)), 1);
+}


### PR DESCRIPTION
Closes #5

> **Scope:** this PR covers **PR 1A only** (layout refactor + filters + settings). PR 1B (context menus + dialog split) and Phase 2 (destructive actions, gated on rolker/udp_bridge#14) are separate PRs on the same issue.

# Plan: UX redesign — PR 1A (layout refactor + filters)

## Issue

https://github.com/rolker/rqt_udp_bridge/issues/5

Scope of **this plan is PR 1A only**. PR 1B (context menus + dialog split) and
Phase 2 (destructive actions, gated on
[rolker/udp_bridge#14](https://github.com/rolker/udp_bridge/issues/14)) are
separate PRs on the same branch family, planned later.

## Context

`udp_bridge_plugin.cpp` (351 lines) + `udp_bridge_plugin.ui` (212) currently
stack four browse trees (`localTopicsTreeView`, `remotesTreeView`,
`remoteTopicsTreeView`, `remoteRemotesTreeView`) in one vertical `splitter`
with a hard-coded `#3030FF` handle stylesheet. No filters; per-connection
detail is a single concatenated string pushed to `selectedRemotedetailsLabel`
via `BridgeNode::remoteDetailsUpdated(remote, connection, details)` (built at
`bridge_node.cpp:362-364`). Models are `QStandardItemModel`s owned by
`BridgeNode`, swapped onto the views with `setModel()` on node/remote change;
per-remote models are created on demand (`remoteTopicsModel(remote)`).
Staleness greying lives in the model via `TimestampRole` (`bridge_node.h:58`).

PR 1A replaces the splitter with a `QTabWidget` + persistent active-remote
header, adds a key/value detail table, and wraps each tree in a filtering proxy
— all UI-side, wrapping services that already exist.

## Approach

1. **`.ui` rebuild** — Replace the `splitter` with the layout from the issue's
   sketch: toolbar (unchanged for 1A) → header `QFrame`
   (`activeRemoteComboBox` + `headlineStatsLabel`) → `QTabWidget` with tabs
   `Local Topics` · `Remotes` · `Topics @ <remote>` · `Peers @ <remote>`.
   Per-remote tabs are `QStackedWidget`: empty-state placeholder vs content.
   Remotes tab is a horizontal `QSplitter`: tree + `selectedRemoteDetailsTable`
   (`QTableView`). Each tab gets a filter row (line-edit · Hide idle · Show
   failing · columns ▾). The `#3030FF` stylesheet disappears with the splitter.
2. **Structured detail accessor in `BridgeNode`** *(settled with Roland)* —
   in the same loop at `bridge_node.cpp:362-364`, keep the tooltip string
   (still used for row hover) but additionally emit structured pairs. Change
   the signal to `remoteDetailsUpdated(QString remote, QString connection,
   QList<QPair<QString,QString>> fields)`. A small `QStandardItemModel`
   (key|value) in the plugin rebuilds on that signal and backs
   `selectedRemoteDetailsTable`. `selectedRemotedetailsLabel` and the string
   form of the signal are removed. No re-parsing in the view.
3. **Stable per-tree `QSortFilterProxyModel`** — one proxy per tree, created
   once in `initPlugin` and never rebuilt. On node/remote change call
   `proxy->setSourceModel(newModel)` (not `view->setModel(newProxy)`), so
   filter text + hidden-column state survive remote switches. Set
   `setRecursiveFilteringEnabled(true)` so a surviving leaf keeps its parent
   row visible (parent rows — remote/topic names — carry no stats).
4. **`mapToSource()` in the tree-walk helpers** — `getRemoteConnection()` and
   `getTopicRemoteConnection()` (lines 255-290) walk `parent()` chains on the
   source model. With proxies in place, `currentChanged` delivers proxy
   indices, so each helper must `mapToSource()` first. This is the highest-risk
   change in 1A — covered by tests in step 7.
5. **Filter row behavior** — line-edit → `setFilterFixedString` on column 0;
   `Hide idle` → custom `filterAcceptsRow` using `TimestampRole` staleness;
   `Show only failing` → rows with nonzero `failed`+`dropped`; columns ▾ →
   `QMenu` toggling `view->setColumnHidden`. Combine idle/failing predicates in
   a `QSortFilterProxyModel` subclass.
6. **Active-remote combo as single source of truth** — combo selection drives
   the per-remote `QStackedWidget` content and the `Topics @`/`Peers @` tab
   labels; the Remotes-tree selection updates the combo. Use `blockSignals`
   discipline so tree→combo→tabs doesn't loop. Folds in the existing
   `currentRemoteChanged` model-swap logic (lines 293-313).
7. **Tests** — add a `launch_testing`/`pytest` smoke (plugin loads, no crash)
   if feasible in CI, **plus** targeted GTest on the proxy index mapping:
   build a known source tree, wrap in the proxy, assert
   `getRemoteConnection`/`getTopicRemoteConnection` return the right
   (remote, connection) / (topic, remote, connection) tuples through the proxy
   (factor the tree-walk into a free function taking a model+index so it is
   testable without a live ROS graph).
8. **Settings persistence** — `saveSettings`/`restoreSettings` gain
   `active_tab`, `active_remote`, per-tab `filter_text`/`hide_idle`/
   `show_failing`, and hidden columns. Old settings (just `node`) must load
   without warnings (verify with the existing `node`-only round-trip).

## Files to Change

| File | Change |
|------|--------|
| `src/udp_bridge_plugin.ui` | Splitter → tabs + header strip + per-tab filter rows + detail `QTableView`; drop `#3030FF` |
| `src/udp_bridge_plugin.cpp` | Proxy wiring, `mapToSource` in helpers, combo SSOT, filter slots, detail-table model, settings keys |
| `include/rqt_udp_bridge/udp_bridge_plugin.h` | Proxy members, detail model, filter-state fields; new slots |
| `src/bridge_node.cpp` | Emit structured detail pairs alongside tooltip string (l.362-365) |
| `include/rqt_udp_bridge/bridge_node.h` | Change `remoteDetailsUpdated` signature to carry key/value pairs |
| new: `src/topic_remote_filter_proxy.{h,cpp}` | `QSortFilterProxyModel` subclass (idle/failing predicates) |
| new: `test/test_index_mapping.cpp` + `CMakeLists.txt` | GTest for proxy index→source tree-walk |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| Human control and transparency | Filters + per-row detail surface bridge state at the point of use; no behavior hidden. |
| A change includes its consequences | `remoteDetailsUpdated` signature change touches every caller (only the plugin); `udp_bridge` README screenshot will need updating post-Phase-1 (noted in PR). |
| Only what's needed | Three filters + column toggle is the issue's agreed set; no sparklines/unit-toggle (explicitly deferred). |
| Improve incrementally | 1A is the layout/proxy foundation; context menus (1B) and destructive actions (Phase 2) land separately. |
| Test what breaks | The proxy index-mapping regression is the real hazard and gets dedicated GTest; rqt Qt+ROS lifecycle limits the rest to smoke. |
| Workspace vs. project separation | All changes are project-side UI; nothing workspace-portable. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0008 — Follow ROS 2 Conventions | Marginally | Preserve `plugin.xml`, `pluginlib` export, `rqt_gui_cpp::Plugin` lifecycle; no new packages/interfaces. |
| 0002 — Worktree isolation | Yes | Landing via `feature/issue-5` worktree + draft PR. |
| 0013 — progress.md vocabulary | Yes | `## Plan Authored` entry written for this plan. |

## Consequences

| If we change... | Also update... | Included? |
|---|---|---|
| `remoteDetailsUpdated` signature | `updateCurrentRemoteDetails` + `updateCurrentRemoteRemoteDetails` callers | Yes |
| `selectedRemotedetailsLabel` removed | `selectedRemoteRemoteDetailsLabel` (remote-remote detail) — mirror to a table or keep label for 1A? | **Open question** |
| `.ui` object names | any `instance_settings` keys referencing them | Yes (settings step) |
| plugin layout | `udp_bridge` README screenshot | No — PR note, follow-up |

## Open Questions

- The **remote-remote** detail pane (`selectedRemoteRemoteDetailsLabel`,
  Peers @ tab) uses the same concatenated-string path. Convert it to a
  key/value table too in 1A for consistency, or leave it as a label this PR
  and migrate in 1B? Leaning: convert both now (same accessor, marginal cost).
- Is `launch_testing` smoke feasible in this repo's CI, or is the GTest
  index-mapping test the only automated coverage for 1A? (CI currently builds
  on `jazzy`; no existing test dir.)

## Estimated Scope

Single PR (PR 1A). Sizable view-layer rewrite but coherent; the proxy/detail
plumbing must land together. PR 1B and Phase 2 follow on the same issue.


---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
