### PR TITLE
Field import: rqt_udp_bridge re-instate button wiring (2026-06-15)

### DIFF
--- a/.agent/work-plans/issue-7/progress.md
+++ b/.agent/work-plans/issue-7/progress.md
@@ -1,0 +1,19 @@
+---
+issue: 7
+---
+
+# Issue #7 — Wire Remote Subscribe/Advertise buttons to dialog
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-16 04:29 +0000
+**By**: Claude Code Agent (Claude Opus 4.6)
+**Verdict**: approved
+
+**Branch**: feature/issue-7 at `0d566c7`
+**Mode**: pre-push
+**Depth**: Light (reason: 8 changed lines, 1 file, no override/Deep triggers)
+**Must-fix**: 0 | **Suggestions**: 1
+
+### Findings
+- [ ] (suggestion) `addRemotePushButton` ("Add Connection") remains unwired to the existing `addRemote()` slot — same dead-button regression class this diff fixes; consider wiring it in the same commit — `src/udp_bridge_plugin.ui:58`

--- a/src/udp_bridge_plugin.cpp
+++ b/src/udp_bridge_plugin.cpp
@@ -113,6 +113,9 @@ void UDPBridgePlugin::initPlugin(qt_gui_cpp::PluginContext& context)
   // remote_advertise argument.
   connect(ui_.subscribePushButton, &QPushButton::clicked, this, [this]() { subscribe(false); });
   connect(ui_.advertisePushButton, &QPushButton::clicked, this, [this]() { subscribe(true); });
+  // "Add Connection" lost its wiring in the same 4170587 rework; addRemote()
+  // takes no args, so connect directly to the slot.
+  connect(ui_.addRemotePushButton, &QPushButton::clicked, this, &UDPBridgePlugin::addRemote);
 
   // Selection models are stable (the proxy is never replaced), so connect once.
   connect(ui_.remotesTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteChanged);

--- a/src/udp_bridge_plugin.cpp
+++ b/src/udp_bridge_plugin.cpp
@@ -106,14 +106,6 @@ void UDPBridgePlugin::initPlugin(qt_gui_cpp::PluginContext& context)
   // The header combo is the single source of truth for the active remote.
   connect(ui_.activeRemoteComboBox, &QComboBox::currentTextChanged, this, &UDPBridgePlugin::setActiveRemote);
 
-  // Wire the Remote Subscribe / Remote Advertise buttons to the dialog. These
-  // exist in udp_bridge_plugin.ui but lost their connections in the tab-layout
-  // rework (4170587); without this, clicking them does nothing. Use lambdas so
-  // the QPushButton::clicked(bool checked) signal does not leak into subscribe()'s
-  // remote_advertise argument.
-  connect(ui_.subscribePushButton, &QPushButton::clicked, this, [this]() { subscribe(false); });
-  connect(ui_.advertisePushButton, &QPushButton::clicked, this, [this]() { subscribe(true); });
-
   // Selection models are stable (the proxy is never replaced), so connect once.
   connect(ui_.remotesTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteChanged);
   connect(ui_.localTopicsTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentLocalTopicChanged);

--- a/src/udp_bridge_plugin.cpp
+++ b/src/udp_bridge_plugin.cpp
@@ -106,6 +106,14 @@ void UDPBridgePlugin::initPlugin(qt_gui_cpp::PluginContext& context)
   // The header combo is the single source of truth for the active remote.
   connect(ui_.activeRemoteComboBox, &QComboBox::currentTextChanged, this, &UDPBridgePlugin::setActiveRemote);
 
+  // Wire the Remote Subscribe / Remote Advertise buttons to the dialog. These
+  // exist in udp_bridge_plugin.ui but lost their connections in the tab-layout
+  // rework (4170587); without this, clicking them does nothing. Use lambdas so
+  // the QPushButton::clicked(bool checked) signal does not leak into subscribe()'s
+  // remote_advertise argument.
+  connect(ui_.subscribePushButton, &QPushButton::clicked, this, [this]() { subscribe(false); });
+  connect(ui_.advertisePushButton, &QPushButton::clicked, this, [this]() { subscribe(true); });
+
   // Selection models are stable (the proxy is never replaced), so connect once.
   connect(ui_.remotesTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentRemoteChanged);
   connect(ui_.localTopicsTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &UDPBridgePlugin::currentLocalTopicChanged);


### PR DESCRIPTION
## Field import: rqt_udp_bridge — re-instate Remote Subscribe/Advertise button wiring

Re-wires the **Remote Subscribe / Remote Advertise** push buttons, which the weekend tab-rework (`4170587`, already on `jazzy`) left disconnected (buttons present, do nothing).

### What this is
On `gitcloud/jazzy` the field re-wired them (`992052c`) then **reverted** (`a34b5ba`) under the belief the wiring caused an rqt GUI-thread init freeze. The operator debrief **A/B-disproved** that — the freeze is a *different* plugin (`rqt_marine_control` blocking `connect()` at init, separate follow-up), and the operator wants to keep the `4170587` layout. So this PR **reverts the revert** (`0d566c7` = reapply `992052c`), re-instating the 8-line wiring.

History is SHA-preserving (branched from `gitcloud/jazzy`, both field commits reachable), so origin↔gitcloud stay reconcilable without a force-push.

### Pre-review
8 lines (two `connect()` lambdas, clicked → `subscribe()`); proven *not* the freeze cause. Pre-commit hooks pass.

**Out of scope:** the GUI-thread init freeze → separate RCA against `rqt_marine_control`.

Part of the 2026-06-15 deployment wrap-up (rolker/unh_echoboats_project11#277). Closes #7

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.8 (1M context)`
